### PR TITLE
适配合宙官方邮箱推送渠道

### DIFF
--- a/script/config.lua
+++ b/script/config.lua
@@ -33,6 +33,10 @@ FEISHU_WEBHOOK = "https://open.feishu.cn/open-apis/bot/v2/hook/xxx"
 
 -- inotify 通知配置, https://github.com/xpnas/Inotify 或者使用合宙提供的 https://push.luatos.org
 -- INOTIFY_API = "https://push.luatos.org/xxx.send"
+-- inotify的消息渠道是否启用了邮箱渠道
+INOTIFY_ENABLE_EMAIL = true
+-- 邮箱推送渠道的KEY
+INOTIFY_EMAIL_KEY=""
 
 -- next-smtp-proxy 通知配置, https://github.com/0wQ/next-smtp-proxy
 -- NEXT_SMTP_PROXY_API = ""

--- a/script/utils/util_notify.lua
+++ b/script/utils/util_notify.lua
@@ -225,7 +225,24 @@ local notify = {
         --     log.error("util_notify", "`config.INOTIFY_API` 必须以 `.send` 结尾")
         --     return
         -- end
-
+        --判断是否启用邮箱渠道
+        if config.INOTIFY_ENABLE_EMAIL and (config.INOTIFY_EMAIL_KEY ~= nil or config.INOTIFY_API ~= "") then
+            log.info("Enable email push")
+            local  data = msg
+            log.info("data:",data)
+            data = data:gsub("%%","%%25")
+                    :gsub("+","%%2B")
+                    :gsub("/","%%2F")
+                    :gsub("?","%%3F")
+                    :gsub("#","%%23")
+                    :gsub("&","%%26")
+                    :gsub(" ","%%20")
+            local title=sim.getNumber().."收到的短信"
+            log.info("title:",title)        
+            local url = "https://push.luatos.org/"..config.INOTIFY_EMAIL_KEY..".send/"..string.urlEncode(title).."/"..string.urlEncode(data)
+            util_http.fetch(nil, "GET", url)
+        end
+        log.info("msg:",msg)
         local url = config.INOTIFY_API .. "/" .. string.urlEncode(msg)
 
         log.info("util_notify", "GET", url)

--- a/script/utils/util_notify.lua
+++ b/script/utils/util_notify.lua
@@ -226,7 +226,7 @@ local notify = {
         --     return
         -- end
         --判断是否启用邮箱渠道
-        if config.INOTIFY_ENABLE_EMAIL and (config.INOTIFY_EMAIL_KEY ~= nil or config.INOTIFY_API ~= "") then
+        if config.INOTIFY_ENABLE_EMAIL and (config.INOTIFY_EMAIL_KEY ~= nil or config.INOTIFY_EMAIL_KEY ~= "") then
             log.info("Enable email push")
             local  data = msg
             log.info("data:",data)


### PR DESCRIPTION
配置合宙官方推送和pushdeer

在合宙的inotify消息渠道中添加（1）企业微信消息和（2）QQ邮箱【经过测试和查看inotify的issue发现不支持163邮箱】



测试结果：
pushdeer：正常收到消息
inotify-企业微信消息：正常收到消息
inotify-QQ邮箱：无法收到消息邮件

在inotify直接测试（1）企业微信消息和（2）QQ邮箱两个渠道：正常
直接复制luatools的log对应的url，放到浏览器中访问：企业微信消息和QQ邮箱两个渠道能正常收到消息



参考资料：
1、查看该作者对合宙推送的邮箱实现逻辑
[chenxuuu](https://github.com/chenxuuu)/[sms_forwarding](https://github.com/chenxuuu/sms_forwarding)

2、各种奇怪的资料

怀疑：应该是在芯片里，lua处理对消息数据处理和传输导致数据，不符合合宙inotify的邮箱数据要求，导致邮箱传输失败。



验证：

修改后邮箱推送给正常。




建议：
本次pr仅供参考。


是否考虑：
1、当sim卡中不存在手机卡号码时候，是否可以通过短信指令的形式，给sim添加一个备注/号码信息，作为设备、sim卡信息？

避免sim.getNumber()获取为空，本机号码显示为空的情况
